### PR TITLE
Remove capital c in #include constants.h

### DIFF
--- a/src/BasicChemistry/chemical_element_data.cpp
+++ b/src/BasicChemistry/chemical_element_data.cpp
@@ -1,12 +1,12 @@
 #include "discamb/BasicChemistry/chemical_element_data.h"
-#include "discamb/BasicUtilities/Constants.h"
+#include "discamb/BasicUtilities/constants.h"
 
 
 namespace {
 
 
-    //Beatriz Cordero, VerÛnica GÛmez, Ana E. Platero-Prats, Marc RevÈs, 
-    // Jorge EcheverrÌa, Eduard Cremades, Flavia Barrag·n and Santiago Alvarez. 
+    //Beatriz Cordero, Ver√≥nica G√≥mez, Ana E. Platero-Prats, Marc Rev√©s, 
+    // Jorge Echeverr√≠a, Eduard Cremades, Flavia Barrag√°n and Santiago Alvarez. 
     // Covalent radii revisited. Dalton Trans., 2008, 2832-2838	
     // au
     const double _covalentRadius[] = {

--- a/src/BasicUtilities/CMakeLists.txt
+++ b/src/BasicUtilities/CMakeLists.txt
@@ -1,4 +1,4 @@
-SET(TARGET_H "${CMAKE_CURRENT_SOURCE_DIR}/../../include/discamb/BasicUtilities/Constants.h"
+SET(TARGET_H "${CMAKE_CURRENT_SOURCE_DIR}/../../include/discamb/BasicUtilities/constants.h"
              "${CMAKE_CURRENT_SOURCE_DIR}/../../include/discamb/BasicUtilities/discamb_env.h"
              "${CMAKE_CURRENT_SOURCE_DIR}/../../include/discamb/BasicUtilities/discamb_version.h"
              "${CMAKE_CURRENT_SOURCE_DIR}/../../include/discamb/BasicUtilities/file_system_utilities.h"

--- a/src/HC_Model/ClementiRaimondiData.cpp
+++ b/src/HC_Model/ClementiRaimondiData.cpp
@@ -1,6 +1,6 @@
 #include "discamb/HC_Model/ClementiRaimondiData.h"
 
-#include "discamb/BasicUtilities/Constants.h"
+#include "discamb/BasicUtilities/constants.h"
 #include "discamb/BasicUtilities/string_utilities.h"
 #include "discamb/BasicUtilities/on_error.h"
 

--- a/src/IO/vtk_io.cpp
+++ b/src/IO/vtk_io.cpp
@@ -1,6 +1,6 @@
 #include "discamb/IO/vtk_io.h"
 #include "discamb/BasicUtilities/on_error.h"
-#include "discamb/BasicUtilities/Constants.h"
+#include "discamb/BasicUtilities/constants.h"
 #include "discamb/IO/xyz_io.h"
 #include "discamb/IO/pdb_io.h"
 

--- a/src/Scattering/NumericalSphericalAtomFormFactor.cpp
+++ b/src/Scattering/NumericalSphericalAtomFormFactor.cpp
@@ -1,6 +1,6 @@
 #include "discamb/Scattering/NumericalSphericalAtomFormFactor.h"
 #include "discamb/MathUtilities/math_utilities.h"
-#include "discamb/BasicUtilities/Constants.h"
+#include "discamb/BasicUtilities/constants.h"
 
 #include <cmath>
 

--- a/src/Scattering/StockholderAtomBankFormFactorCalculationManager.cpp
+++ b/src/Scattering/StockholderAtomBankFormFactorCalculationManager.cpp
@@ -1,7 +1,7 @@
 #include "discamb/Scattering/StockholderAtomBankFormFactorCalculationManager.h"
 
 #include "discamb/BasicUtilities/on_error.h"
-#include "discamb/BasicUtilities/Constants.h"
+#include "discamb/BasicUtilities/constants.h"
 #include "discamb/IO/atom_type_io.h"
 #include "discamb/IO/tham_io.h"
 #include "discamb/MathUtilities/radial_grid.h"

--- a/src/Scattering/StockholderAtomFormFactorCalcManager.cpp
+++ b/src/Scattering/StockholderAtomFormFactorCalcManager.cpp
@@ -2,7 +2,7 @@
 #include "discamb/MathUtilities/SphericalHarmonics.h"
 #include "discamb/BasicChemistry/periodic_table.h"
 #include "discamb/CrystalStructure/ReciprocalLatticeUnitCell.h"
-#include "discamb/BasicUtilities/Constants.h"
+#include "discamb/BasicUtilities/constants.h"
 #include "discamb/BasicUtilities/on_error.h"
 #include "discamb/BasicUtilities/string_utilities.h"
 #include "discamb/BasicUtilities/Timer.h"

--- a/src/StructuralProperties/CovalentRadiousBondDetector.cpp
+++ b/src/StructuralProperties/CovalentRadiousBondDetector.cpp
@@ -1,7 +1,7 @@
 #include "discamb/StructuralProperties/CovalentRadiousBondDetector.h"
 #include "discamb/BasicChemistry/chemical_element_data.h"
 
-#include "discamb/BasicUtilities/Constants.h"
+#include "discamb/BasicUtilities/constants.h"
 
 #include <cmath>
 

--- a/src/StructuralProperties/structural_properties.cpp
+++ b/src/StructuralProperties/structural_properties.cpp
@@ -1,7 +1,7 @@
 #include "discamb/BasicChemistry/basic_chemistry_utilities.h"
 #include "discamb/BasicChemistry/chemical_element_data.h"
 
-#include "discamb/BasicUtilities/Constants.h"
+#include "discamb/BasicUtilities/constants.h"
 #include "discamb/BasicUtilities/on_error.h"
 
 #include "discamb/CrystalStructure/UnitCellContent.h"
@@ -792,7 +792,7 @@ namespace
     {"C(ar)-H",1.083},         // Allen 2010
     {"Z2-Csp3-H2",1.091},      // Allen 2010
     {"Z3-Csp3-H",1.098},       // Allen 2010
-    {"H-O-H",0.959},           // Woiñska et al. (2016, Sci. Adv. 2, e1600192) 
+    {"H-O-H",0.959},           // WoiÃ±ska et al. (2016, Sci. Adv. 2, e1600192) 
     {"Csp3-O-H",0.97},         // Allen 2010
     {"C(ar)-O-H",0.992},       // Allen 2010
     {"O=Csp2-O-H",1.018},      // Allen 2010


### PR DESCRIPTION
Hello,
My compiler complained about capitalization of "Constants.h", which is now renamed "constants.h".
These are all the instances I found, and after changing them it compiled without issue with gcc 11.4 and cmake 3.22.3.
