### PR TITLE
Add support for anomalous scattering without calculating derivatives

### DIFF
--- a/src/Scattering/AnyScattererStructureFactorCalculator.cpp
+++ b/src/Scattering/AnyScattererStructureFactorCalculator.cpp
@@ -371,7 +371,7 @@ namespace discamb{
 						complex<REAL> atomic_position_phase_factor(atomic_phase_factor_real, atomic_phase_factor_im);
 
 
-						atom_ff = atomic_ff[symOpIdx][atomIdx];// mManager->calculateCart(atomIdx, rotated_h_ref);
+						atom_ff = atomic_ff[symOpIdx][atomIdx] + mAnomalous[atomIdx];// mManager->calculateCart(atomIdx, rotated_h_ref);
 
 
 						if (n_adp_components == 6)


### PR DESCRIPTION
Hello,

I tried calculating structure factors using the following:

```cpp
// Set up crystal, hkl ect.
...
// set up calculator
    shared_ptr<AtomicFormFactorCalculationsManager> formfactorCalculator;
    formfactorCalculator = shared_ptr<AtomicFormFactorCalculationsManager>(
        new IamFormFactorCalculationsManager(crystal, table));
    AnyScattererStructureFactorCalculator calculator(crystal);
    calculator.setAtomicFormfactorManager(formfactorCalculator);

// set anomalous scattering parameters
    calculator.setAnoumalous(mAnomalous);

// Calculate
    calculator.calculateStructureFactors(hkl, sf);
```
However, it seems `calculateStructureFactors` does not take the anomalous scattering into account.
I see `calculateStructureFactorsAndDerivatives` supports it, but only when calculating for a single hkl, not when using a vector of hkls. I don't know if this is an oversight or I might be doing something wrong, maybe there is another calculations manager I should use?

Regardless, I believe the change in this PR is the correct place to account for the anomalous scattering, by comparing with the code in the other functions including derivatives (i.e. https://github.com/discamb-project/DiSCaMB/blob/0065c7ed5c0d7a9317fc96b332fca82ed772b911/src/Scattering/AnyScattererStructureFactorCalculator.cpp#L1012).