### PR TITLE
Fix NGaussianFormFactor::mN desync

### DIFF
--- a/src/Scattering/NGaussianFormFactor.cpp
+++ b/src/Scattering/NGaussianFormFactor.cpp
@@ -98,7 +98,7 @@ const
 {
     double result=0;
     int  n = mA.size();
-    for(int i=0; i < mN; i++)
+    for(int i=0; i < n; i++)
         result += mA[i] * exp( -mB[i] * x * x );
 
     return result + mC;


### PR DESCRIPTION
Hello,

Manually setting gaussian scattering parameters does not work correctly, seemingly due to a desync between mN and the sizes of the parameter arrays. 
This PR fixes this for NGaussianFormFactor::calculate_sinth, but not the underlying issue of mN desync.

To reproduce: 
https://github.com/viljarjf/pyDiSCaMB/blob/a8f6d8e732f3dad82b9c6ab88453bd954aa992a7/tests/test_correctness.py#L99-L126
