### PR TITLE
Remove incomplete dev feature from compilation

### DIFF
--- a/src/Scattering/CMakeLists.txt
+++ b/src/Scattering/CMakeLists.txt
@@ -52,7 +52,7 @@ SET(TARGET_SRC
     gar_utilities.cpp
     HansenCoppens_SF_Engine.cpp 
     HansenCoppensStructureFactorCalculator.cpp 
-    HansenCoppensStructureFactorCalculatorDev.cpp 
+    # HansenCoppensStructureFactorCalculatorDev.cpp 
     HcAtomBankStructureFactorCalculator.cpp
     HcFormFactorCalculationsManager.cpp
     HirshfeldAtomModelSettings.cpp


### PR DESCRIPTION
Hello,

I am having compilation issues on the newest version, with HansenCoppensStructureFactorCalculatorDev. I suggest removing it from the "Scattering"-target.
