### PR TITLE
Only set lcs when atom type is known

### DIFF
--- a/src/Scattering/HcAtomBankStructureFactorCalculator.cpp
+++ b/src/Scattering/HcAtomBankStructureFactorCalculator.cpp
@@ -270,11 +270,14 @@ namespace discamb {
         //    multipoleModelPalameters, true, nonMultipolarAtoms);
 
         vector<shared_ptr<LocalCoordinateSystemInCrystal> > lcaCalculators;
-        for (auto coordinateSystem : lcs)
+        for (int lcsIdx = 0; lcsIdx < lcs.size(); lcsIdx++)
             lcaCalculators.push_back(
                 shared_ptr<LocalCoordinateSystemInCrystal>(
-                    new LocalCoordinateSystemCalculator(coordinateSystem, crystal)));
-
+                    types[lcsIdx] > 0 ?
+                    new LocalCoordinateSystemCalculator(lcs[lcsIdx], crystal) :
+                    new LocalCoordinateSystemCalculator()
+                )
+            );
         if (!parametersInfoFile.empty())
             printAssignedMultipolarParameters(
                 parametersInfoFile,


### PR DESCRIPTION
All LocalCoordinateSystemCalculator were initialized with the LocalCoordinateSystem<AtomInCrystalID> from reading the bank and crystal. This caused issues when atom(s) in the crystal were greater than 36, and were therefore unrecognized. This caused the lcs to be undefined (both directions were set to LcsDirectionType::NOT_SET), which caused an error later when initializing LocalCoordinateSystemCalculator, in AtomTyping/LocalCoordinateSystemCalculator.cpp line 227. 
To mitigate this, the calculators corresponding to unassigned atoms are now initialized with default values, which includes a safety switch to return before the error in line 227.

Tests which fail without this fix, and pass with this fix, are available here: https://github.com/viljarjf/pyDiSCaMB/blob/c7be2e05d146d2a0389e48e69431175bf7f3ed2e/tests/test_taam.py#L34-L59