### PR TITLE
Suggestion: log spherical assignment vs not assigned

### DIFF
--- a/src/AtomTyping/CrystalAtomTypeAssigner.cpp
+++ b/src/AtomTyping/CrystalAtomTypeAssigner.cpp
@@ -108,11 +108,11 @@ namespace discamb {
         out << "Atom type assigned to " << nAssigned << " of " << nAtoms << ".\n";
         if (nAssigned != nAtoms)
         {
-            out << "Atoms with unassigned atom types :\n";
+            out << "Atoms with unassigned atom types, represented with standard IAM :\n";
             for (atomIdx = 0; atomIdx < nAtoms; atomIdx++)
                 if (typeID[atomIdx] < 0)
                     out << setw(maxAtomLabelWidth + 3) << crystal.atoms[atomIdx].label << "\n";
-            out << "Atoms with spherical atom type :\n";
+            out << "Atoms with unassigned atom types, represented with multipole model based IAM :\n";
             for (atomIdx = 0; atomIdx < nAtoms; atomIdx++)
                 if (typeID[atomIdx] >= 0 && isSphericalType(mTypeLabels[typeID[atomIdx]]))
                         out << setw(maxAtomLabelWidth + 3) << crystal.atoms[atomIdx].label << "\n";

--- a/src/AtomTyping/CrystalAtomTypeAssigner.cpp
+++ b/src/AtomTyping/CrystalAtomTypeAssigner.cpp
@@ -112,8 +112,9 @@ namespace discamb {
             for (atomIdx = 0; atomIdx < nAtoms; atomIdx++)
                 if (typeID[atomIdx] < 0)
                     out << setw(maxAtomLabelWidth + 3) << crystal.atoms[atomIdx].label << "\n";
-                else
-                    if (isSphericalType(mTypeLabels[typeID[atomIdx]]))
+            out << "Atoms with spherical atom type :\n";
+            for (atomIdx = 0; atomIdx < nAtoms; atomIdx++)
+                if (typeID[atomIdx] >= 0 && isSphericalType(mTypeLabels[typeID[atomIdx]]))
                         out << setw(maxAtomLabelWidth + 3) << crystal.atoms[atomIdx].label << "\n";
         }
         if (nAssigned > 0)


### PR DESCRIPTION
When using `HcAtomBankStructureFactorCalculator`, atoms with atomic number >36 are handled by an IAM calculator, rather than with spherical parameters in a HC calculator. I think this can be specified in the type assignment log.

Example before:
```
Atom type assigned to 0 of 2.
Atoms with unassigned atom types :
   H1
   Au2
```
After this change:
```
Atom type assigned to 0 of 2.
Atoms with unassigned atom types :
   Au2
Atoms with spherical atom type :
    H1

```