### PR TITLE
Add option to choose table for IAM in HcAtomBankStructureFactorCalcator

### DIFF
--- a/include/discamb/Scattering/HcAtomBankStructureFactorCalculator.h
+++ b/include/discamb/Scattering/HcAtomBankStructureFactorCalculator.h
@@ -44,7 +44,9 @@ namespace discamb {
             const std::string& multipolarCif = std::string(),
             int nThreads = 1,
             double unitCellCharge = 0,
-            bool scaleToMatchCharge = true);
+            bool scaleToMatchCharge = true,
+            const std::string& iamTable = std::string(),
+            bool iamElectronScattering = false);
         
         HcAtomBankStructureFactorCalculator(const Crystal &crystal, const nlohmann::json &data);
         virtual void getModelInformation(std::vector<std::pair<std::string, std::string> >& modelInfo) const;
@@ -59,7 +61,9 @@ namespace discamb {
             const std::string& multipolarCif = std::string(),
             int nThreads = 1,
             double unitCellCharge = 0,
-            bool scaleToMatchCharge = true);
+            bool scaleToMatchCharge = true,
+            const std::string& iamTable = std::string(),
+            bool iamElectronScattering = false);
         
 
         virtual ~HcAtomBankStructureFactorCalculator();

--- a/src/Scattering/HcAtomBankStructureFactorCalculator.cpp
+++ b/src/Scattering/HcAtomBankStructureFactorCalculator.cpp
@@ -61,9 +61,11 @@ namespace discamb {
         const std::string& multipolarCif,
         int nThreads,
         double unitCellCharge,
-        bool scaleToMatchCharge)
+        bool scaleToMatchCharge,
+        const string& iamTable,
+        bool iamElectronScattering)
     {
-        set(crystal, atomTypes, parameters, electronScattering, settings, assignemntInfoFile, parametersInfoFile, multipolarCif, nThreads, unitCellCharge, scaleToMatchCharge);
+        set(crystal, atomTypes, parameters, electronScattering, settings, assignemntInfoFile, parametersInfoFile, multipolarCif, nThreads, unitCellCharge, scaleToMatchCharge, iamTable, iamElectronScattering);
 
     }
 
@@ -106,10 +108,17 @@ namespace discamb {
         if (data.find("scale") != data.end())
             scaleHcParameters = data.find("scale")->get<bool>();
 
-
         int nCores=1;
         if (data.find("n cores") != data.end())
             nCores = data.find("n cores")->get<int>();
+
+        string iamTable;
+        if (data.find("table") != data.end())
+            iamTable = data.find("table")->get<string>();
+        
+        bool iamElectronScattering = false;
+        if (data.find("iam electron scattering") != data.end())
+            iamElectronScattering = data.find("iam electron scattering")->get<bool>();
 
 
         MATTS_BankReader bankReader;
@@ -149,7 +158,7 @@ namespace discamb {
 		else
 			bankReader.read(bankPath, types, hcParameters, bankSettings, true);
         set(crystal,types, hcParameters, electronScattering, DescriptorsSettings(), assignmentInfoFile,
-            parametersInfoFile, multipolarCif, nCores, unitCellCharge, scaleHcParameters);
+            parametersInfoFile, multipolarCif, nCores, unitCellCharge, scaleHcParameters, iamTable, iamElectronScattering);
     }
 
 
@@ -174,7 +183,9 @@ namespace discamb {
         const std::string& multipolarCif,
         int nThreads,
         double unitCellCharge,
-        bool scaleToMatchCharge)
+        bool scaleToMatchCharge,
+        const string& iamTable,
+        bool iamElectronScattering)
     {
         mModelInfo.clear();
 
@@ -291,7 +302,7 @@ namespace discamb {
         mHcCalculator = shared_ptr<SfCalculator>(
                             new AnyHcCalculator(crystal, multipoleModelPalameters, lcaCalculators, electronScattering, false));
         mIamCalculator = shared_ptr<SfCalculator>(
-            new AnyIamCalculator(crystal, electronScattering));
+            new AnyIamCalculator(crystal, iamElectronScattering, iamTable));
         vector< std::shared_ptr<SfCalculator> > calculators{ mHcCalculator, mIamCalculator };
         vector<vector<int> > calculatorAtoms(2);
         for (int atomIdx = 0; atomIdx < crystal.atoms.size(); atomIdx++)
@@ -316,7 +327,7 @@ namespace discamb {
             mHcCalculators.push_back(shared_ptr<SfCalculator>(
                 new AnyHcCalculator(crystal, multipoleModelPalameters, lcaCalculators, electronScattering, false)));
             mIamCalculators.push_back(shared_ptr<SfCalculator>(
-                new AnyIamCalculator(crystal, electronScattering)));
+                new AnyIamCalculator(crystal, iamElectronScattering, iamTable)));
 
             vector< std::shared_ptr<SfCalculator> > calculators2{ mHcCalculators.back(), mIamCalculators.back() };
             mCalculators.push_back(shared_ptr< CombinedStructureFactorCalculator>(new CombinedStructureFactorCalculator(calculators2, calculatorAtoms)));


### PR DESCRIPTION
Unassigned atoms (atomic numbers above 36) have their structure factors calculated using IAM when using `HcAtomBankStructureFactorCalcator`. This PR change allows users to set the scattering table used for these calculations. The default is an empty string, which is the same behavior as before.

In the constructor using json, I used "table" (the same as the IAM parameter), and "iam electron scattering" as the keys. Please let me know if these are appropriate names, or should be changed (e.g. capitalizing IAM). 