### PR TITLE
Delete calculator pointer in destructor

### DIFF
--- a/src/Scattering/AnyIamCalculator.cpp
+++ b/src/Scattering/AnyIamCalculator.cpp
@@ -139,7 +139,9 @@ namespace discamb {
 
     }
 
-    AnyIamCalculator::~AnyIamCalculator() {}
+    AnyIamCalculator::~AnyIamCalculator() {
+        delete mCalculator;
+    }
 
     void AnyIamCalculator::getModelInformation(std::vector<std::pair<std::string, std::string> >& modelInfo)
         const


### PR DESCRIPTION
Fixes a memory leak where the mCalculator member was not properly deleted.