### PR TITLE
Delete calculator pointers in destructors

### DIFF
--- a/include/discamb/Scattering/TscFileBasedSfCalculator.h
+++ b/include/discamb/Scattering/TscFileBasedSfCalculator.h
@@ -22,7 +22,7 @@ namespace discamb {
 
 		TscFileBasedSfCalculator(const Crystal& crystal, const nlohmann::json& data);
 
-		virtual ~TscFileBasedSfCalculator() {};
+		virtual ~TscFileBasedSfCalculator();
         virtual void getModelInformation(std::vector<std::pair<std::string, std::string> >& modelInfo) const {};
 		virtual void setAnomalous(const std::vector<std::complex<double> >& anomalous);
 		virtual void calculateStructureFactorsAndDerivatives(

--- a/src/Scattering/AnyIamCalculator.cpp
+++ b/src/Scattering/AnyIamCalculator.cpp
@@ -148,6 +148,7 @@ namespace discamb {
 
     AnyIamCalculator::~AnyIamCalculator() {
         delete mCalculator;
+        delete mCalculator2;
     }
 
     void AnyIamCalculator::getModelInformation(std::vector<std::pair<std::string, std::string> >& modelInfo)

--- a/src/Scattering/TscFileBasedSfCalculator.cpp
+++ b/src/Scattering/TscFileBasedSfCalculator.cpp
@@ -157,5 +157,8 @@ namespace discamb {
 		mCalculator->calculateFormFactors(hkl, formFactors, includeAtom);
 	}
 
-
+	TscFileBasedSfCalculator::~TscFileBasedSfCalculator(){
+		delete mCalculator;
+	}
+	
 }


### PR DESCRIPTION
Hello,

pydiscamb has a simple memory leak test, where it initializes and deletes a couple hundred calculators on the python side and deletes them. It then checks if the same memory is used by the python process afterwards. This PR fixes the failing test for IAM.

TAAM still fails the first time (this started after the latest update to discamb), but the second and third run it passes the test. I have no idea why, I looked around in the code but nothing jumped out at me.
The Tsc calculator is not something I used, but I found it while looking for anything that could affect TAAM.